### PR TITLE
updated conda env

### DIFF
--- a/nhmusgs-base/Dockerfile
+++ b/nhmusgs-base/Dockerfile
@@ -11,22 +11,23 @@ RUN apt-get update && \
 # Update/upgrade Conda
 RUN conda update -n base conda -y && \
     conda install -n base -c defaults -c conda-forge \
-      python=3.6 \
-      bottleneck=1.2.1 \
-      cartopy=0.17.0 \
-      dask=2.6.0 \
-      geopandas=0.4.1 \
-      jupyter=1.0.0 \
-      matplotlib=3.1.1 \
-      netcdf4=1.4.2 \
-      notebook=5.7.4 \
-      numpy=1.17.2 \
-      pandas=0.25.2 \
-      rasterio=1.0.21 \
-      rasterstats=0.13.1 \
-      scipy=1.3.1 \
-      xarray=0.13.0 \
-      xmltodict=0.12.0 && \
+    rasterstats=0.13.1 \
+    jupyter=1.0.0 \
+    notebook=6.0.1 \
+    cartopy=0.17.0 \
+    python=3.7 \
+    matplotlib=3.1.1 \
+    rasterio=1.0.21 \
+    cipy=1.3.1 \
+    docker-py=4.0.2 \
+    xarray=0.13.0 \
+    geopandas=0.4.1 \
+    xmltodict=0.12.0 \
+    numpy=1.17.2 \
+    dask=2.6.0 \
+    netcdf4=1.4.2 \
+    bottleneck=1.2.1 \
+    pandas=0.25.2 && \
     conda clean -a
 
 ENV SOURCE_DIR=/usr/local/src


### PR DESCRIPTION
I tested these env changes by create a new conda env with the copied env file and ran the onhm-fetcher -parser with it.  It uses python 3.7 I have not tested it here!

name: ofp_env2
channels:
- defaults
- conda-forge
dependencies:
  - rasterstats=0.13.1
  - jupyter=1.0.0
  - notebook=6.0.1
  - cartopy=0.17.0
  - python=3.7
  - matplotlib=3.1.1
  - rasterio=1.0.21
  - scipy=1.3.1
  - docker-py=4.0.2
  - xarray=0.13.0
  - geopandas=0.4.1
  - xmltodict=0.12.0
  - numpy=1.17.2
  - dask=2.6.0
  - netcdf4=1.4.2
  - bottleneck=1.2.1
  - pandas=0.25.2
prefix: /home/rmcd/anaconda3/envs/ofp_env2
