### PR TITLE
Removed ARGV ENV declaration and removed $ARGV from ENTRYPOINT argument in nhm-prms Dockerfile, and:

### DIFF
--- a/nhmusgs-nhm-prms/Dockerfile
+++ b/nhmusgs-nhm-prms/Dockerfile
@@ -24,6 +24,4 @@ USER $USER
 
 WORKDIR /home/$USER
 
-ENV ARGV=""
-
-ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/prms", "$ARGV"]
+ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/prms"]

--- a/nhmusgs-nhm-prms/prms
+++ b/nhmusgs-nhm-prms/prms
@@ -9,4 +9,11 @@
 # Authors - Andrew Halper, Steven Markstrom
 #
 
-$NHM_SOURCE_DIR/prms/prms/prms $*
+if [ "$NHM_DRY_RUN" = true ]; then
+	echo "nhm-prms service entry-point in dry-run mode:"
+	echo
+	echo "   ARGV: $ARGV"
+	exit 0
+fi
+
+$NHM_SOURCE_DIR/prms/prms/prms $ARGV


### PR DESCRIPTION
reverted to previous version of nhm-prms entrypoint script.