### PR TITLE
Fix restart date

### DIFF
--- a/nhm.env
+++ b/nhm.env
@@ -33,6 +33,7 @@ GRIDMET_DISABLE=false
 # feasible.
 START_DATE=
 END_DATE=
+SAVE_RESTART_DATE=
 
 # When "true", tell the Docker entry-point scripts to print values of
 # relevant environment variables to stdout, then exit, without running

--- a/run
+++ b/run
@@ -169,6 +169,10 @@ if [ "$START_DATE" = "" ]; then
     START_DATE=`date --date "$RESTART_DATE +1 day" --rfc-3339='date'`
 fi
 
+if [ "$SAVE_RESTART_DATE" = ""]; then
+    SAVE_RESTART_DATE=`date --date "$yesterday -59 days" --rfc-3339='date'`
+fi
+
 # if we want to run the Gridmet service...
 if [ "$GRIDMET_DISABLE" != true ]; then
   run gridmet
@@ -197,7 +201,7 @@ done
 # end time is start date + 1 day in PRMS end_date datetime format
 END_TIME=`date --date "$yesterday -59 days" +%Y,%m,%d,00,00,00`
 SAVE_VARS_TO_FILE=1
-VAR_SAVE_FILE="-set var_save_file $DIR/restart/$END_TIME.restart"
+VAR_SAVE_FILE="-set var_save_file $DIR/restart/$SAVE_RESART_DATE.restart"
 
 run nhm-prms
 


### PR DESCRIPTION
Check fix to the "new" restart date as saved in the VAR_SAVE_FILE for the second PRMS run.  Added SAVE_RESTART_DATE to nhm.env and the followed patterns for other vars to set SAVE_RESTART_DATE.  Please check my coding because it's all pattern recognition - because I'm not sure about the shell scripting.  