### PR TITLE
fixed spelling error of var SAVE_RESTART_DATE

### DIFF
--- a/run
+++ b/run
@@ -201,7 +201,7 @@ done
 # end time is start date + 1 day in PRMS end_date datetime format
 END_TIME=`date --date "$yesterday -59 days" +%Y,%m,%d,00,00,00`
 SAVE_VARS_TO_FILE=1
-VAR_SAVE_FILE="-set var_save_file $DIR/restart/$SAVE_RESART_DATE.restart"
+VAR_SAVE_FILE="-set var_save_file $DIR/restart/$SAVE_RESTART_DATE.restart"
 
 run nhm-prms
 


### PR DESCRIPTION
Andy give this a look-over.  Frustrating! I'm pretty sure this will work.