### PR TITLE
Restart fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       - SAVE_VARS_TO_FILE
       - START_DATE
       - START_TIME
+      - RESTART_DATE
     env_file:
       - nhm.env
     volumes:

--- a/nhm.env
+++ b/nhm.env
@@ -11,13 +11,13 @@
 NHM_SOURCE_DIR=/usr/local/src
 
 # HRU shapefile data path prefix
-HRU_DATA_PREFIX=/caldera/projects/usgs/water/impd/$USER/ofp
+HRU_DATA_PREFIX=/home/rmcd/temp
 
 # name of HRU shapefile archive
 HRU_DATA_PKG=Data_hru_shp_v2.tar.gz
 
 # PRMS data path prefix
-PRMS_DATA_PREFIX=/caldera/projects/usgs/water/impd/$USER
+PRMS_DATA_PREFIX=/home/rmcd/temp
 
 # name of PRMS data file archive
 PRMS_DATA_PKG=NHM-PRMS_CONUS.zip
@@ -32,13 +32,13 @@ PRMS_SOURCE=ftp://ftpext.usgs.gov/pub/cr/co/denver/BRR-CR/pub/markstro/$PRMS_DAT
 # data is not typically available until ~2:00 p.m., so disabling the
 # gridmet container can be useful in development to prevent the
 # pipeline from stopping at this step with an error.
-GRIDMET_DISABLE=false
+GRIDMET_DISABLE=true
 
 # Simulation interval. Presently used only in testing to diminish
 # pipeline run-time to a point where interactive testing is
 # feasible.
 START_DATE=
-END_DATE=
+END_DATE=2019-10-04
 SAVE_RESTART_DATE=
 
 # When "true", tell the Docker entry-point scripts to print values of

--- a/nhmusgs-nhm-prms/prms
+++ b/nhmusgs-nhm-prms/prms
@@ -18,6 +18,7 @@ if [ "$NHM_DRY_RUN" = true ]; then
 	echo "   START_DATE: $START_DATE"
 	echo "   START_TIME: $START_TIME"
 	echo "   VAR_SAVE_FILE: $VAR_SAVE_FILE"
+	echo "   RESTART_DATE: $RESTART_DATE"
 	exit 0
 fi
 

--- a/run.sl
+++ b/run.sl
@@ -112,6 +112,7 @@ else
 		       nhmusgs/base bash -c 'ls *.restart' | \
 	   	sort | tail -1 | cut -f1 -d .`
 fi
+echo "$RESTART_DATE"
 # end date is yesterday
 yesterday=`date --date yesterday --rfc-3339='date'`
 
@@ -152,7 +153,9 @@ run verifier
 # run PRMS service in restart mode
 
 # end time is start date + 1 day in PRMS end_date datetime format
-END_TIME=`date --date "$yesterday -59 days" +%Y,%m,%d,00,00,00`
+if [ "$GRIDMET_DISABLE" != true ]; then #otherwise it's debug and use END_DATE specified in nhm.env
+  END_TIME=`date --date "$yesterday -59 days" +%Y,%m,%d,00,00,00`
+fi
 SAVE_VARS_TO_FILE=1
 VAR_SAVE_FILE="-set var_save_file /nhm/NHM-PRMS_CONUS/restart/$SAVE_RESTART_DATE.restart"
 


### PR DESCRIPTION
Andy, be sure to check the change I made to end_date for the second PRMS run.  I assumed if gridmet was turned off then debugging was set and and end_date would have been set.  I'm sure this would break under some conditions but it works for debugging with an end_date set.