### PR TITLE
Supply the path to PRMS dataset with a command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,8 @@ services:
       - nhm.env
     volumes:
       - nhm:/nhm
+    command:
+      - "/nhm/NHM-PRMS_CONUS_GF_1_1/"
 
   thredds:
     image: unidata/thredds-docker:4.6.13

--- a/nhmusgs-verifier/Dockerfile
+++ b/nhmusgs-verifier/Dockerfile
@@ -15,4 +15,4 @@ USER $USER
 WORKDIR /home/$USER
 
 ENTRYPOINT \
-  ["/opt/conda/bin/python", "-u", "/usr/local/src/onhm-verify-eval/src/prms_verifier.py", "/nhm/NHM-PRMS_CONUS_GF_1_1/"]
+  ["/opt/conda/bin/python", "-u", "/usr/local/src/onhm-verify-eval/src/prms_verifier.py"]


### PR DESCRIPTION
Instead of adding the PRMS dataset directory to the end of the
entrypoint. This supplies it via command so it can be changed for each
version of the pipeline.