### PR TITLE
updated tag for gridmetetl repo, fix to how datetime.now() is calc in…

### DIFF
--- a/nhmusgs-gridmet/Dockerfile
+++ b/nhmusgs-gridmet/Dockerfile
@@ -2,7 +2,7 @@ FROM nhmusgs/base
 
 LABEL maintainer="ashalper@usgs.gov"
 
-ARG VERSION_TAG_GRIDMET=v0.22
+ARG VERSION_TAG_GRIDMET=v0.23
 
 # check out source from repo.
 RUN git -c advice.detachedHead=false clone --depth=1 --branch $VERSION_TAG_GRIDMET \


### PR DESCRIPTION
… Gridmet_current.py, enforces check at MST