### PR TITLE
Moved mkdir -p /nhm/gridmetetl/Output command:

### DIFF
--- a/nhmusgs-base/Dockerfile
+++ b/nhmusgs-base/Dockerfile
@@ -49,8 +49,6 @@ RUN cd $NHM_SOURCE_DIR && tar -xvzf $VERSION_TAG_GRIDMETETL.tar.gz
 RUN mv $NHM_SOURCE_DIR/gridmetetl-$VERSION_TAG_GRIDMETETL $NHM_SOURCE_DIR/gridmetetl
 RUN rm $NHM_SOURCE_DIR/$VERSION_TAG_GRIDMETETL.tar.gz
 
-RUN mkdir -p /nhm/gridmetetl/Output
-
 ENV USER=nhm
 RUN useradd -ms /bin/bash $USER
 

--- a/nhmusgs-data-loader/data-loader
+++ b/nhmusgs-data-loader/data-loader
@@ -15,6 +15,8 @@ fi
 
 set -e
 
+mkdir -p /nhm/gridmetetl/Output
+
 if [ -f /nhm/gridmetetl/$HRU_DATA_PKG ]; then
     echo "HRU shapefiles already loaded"
 else


### PR DESCRIPTION
... from base image `Dockerfile` to `data-loader` entry-point due to its present uselessness on Shifter.